### PR TITLE
feat: turn message accepted into a js object and let it include the t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,48 @@
 # origo-iframe-etuna
 
-Ger ett API för att styra delar av Origo inuti en `<iframe>`.
+Ger ett API för att styra delar av Origo inuti en `<iframe>` via https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
-### Parametrar
+### Parametrar för pluginens inställning
 
-- `layerName`: Det lager som "styrs". **Obligatorisk**.
 - `layerIDField`: Fältet i lagret som används som unikt ID. **Obligatorisk**.
 - `maxZoom`: Maximal inzoomningsnivå. **Valfri**.
 - `zoomDuration`: Tid (i millisekunder) för att genomföra en zoomning. **Valfri**.
 
 ### Meddelanden
 
-- `setFilter:<cql>`: Sätt ett eget CQL filter.
-- `setVisibleIDs:<id1>,<id2>,...,<idn>`: Filtrera så att enbart features vars `layerIDField` har något av dessa värden visas.
-- `resetFilter`: Nollställ filtret, visa alla features.
-- `zoomTo:<id1>,<id2>,...,<idn>`: Zooma till mitten av de features vars `layerIDField` matchar ett `<id>`.
-- `panTo:<id1>,<id2>,...,<idn>`: Panorera till mitten av de features vars `layerIDField` matchar ett `<id>`.
+Meddelanden som skickas via postMessage till en Origo-karta med den här pluginen bär ett message som är ett vanligt javascript-objekt med följande egenskaper:
+- `command`
+- `targetLayer`
+samt antingen 
+- `filter`
+eller
+- `ids`
 
-### Exempel
+`command` är ett av följande:
+
+- `setFilter` sätt ett eget CQL filter.
+- `setVisibleIDs` filtrera så att enbart features vars `layerIDField` matchar ett av idn:a i `ids`.
+- `resetFilter` nollställ filtret, visa alla features.
+- `zoomTo` zooma till mitten av de features vars `layerIDField` matchar ett av idn:a i `ids`.
+- `panTo` panorera till mitten av de features vars `layerIDField` matchar ett av idn:a i `ids`.
+
+Exempelobjekt:
+```javascript
+		const zoomToMessage = {
+			command: 'zoomTo',
+    		targetLayer: 'sokvyxw_utegym',
+			ids: ['uuid4', 'uuid5', 'uuid9']
+		}
+```
+
+### Exempelinställning:
 
 ```html
 <script type="text/javascript">
     var origo = Origo('index.json');
     origo.on('load', function (viewer) {
       var origoiframeetuna = Origoiframeetuna({
-          layerName: "sokvyx_park_park_lekplats",
-          layerIDField: "sokid",
+          layerIDField: "globalId",
           maxZoom: 11,
           zoomDuration: 750
       });
@@ -39,4 +56,18 @@ Ger ett API för att styra delar av Origo inuti en `<iframe>`.
 1. Clona Origo och detta repo
 2. Kör `npm install` i båda repon
 3. Kör `npm start` i båda repon
-4. Öppna `https://localhost:9010/demo/` i en webbläsare
+4. Öppna `https://localhost:9001/demo/` i en webbläsare
+
+(om CORS-fel så kan något som följande behövas i Origos tasks/webpack.dev.js:
+```javascript
+  devServer: {
+    static: {
+      directory: './'
+    },
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+      "Access-Control-Allow-Headers": "X-Requested-With, content-type, Authorization"
+    },
+```
+)

--- a/demo/embedded/index.html
+++ b/demo/embedded/index.html
@@ -22,8 +22,7 @@
 	var origo = Origo('index.json', { svgSpritePath: 'http://localhost:9966/css/svg/' });
 	origo.on('load', function (viewer) {
 	  var origoiframeetuna = Origoiframeetuna({
-		  layerName: "sokvyx_park_park_lekplats",
-		  layerIDField: "sokid",
+		  layerIDField: "sv_global_id",
 		  maxZoom: 11,
 		  zoomDuration: 750
 	  });

--- a/demo/embedded/index.json
+++ b/demo/embedded/index.json
@@ -147,7 +147,10 @@
       "queryable": true,
       "type": "WMS",
       "visible": true,
-      "source": "etuna"
+      "source": "etuna",
+      "legendParams" : {
+        "legend_options" : "dpi:300"
+      }
   },
 
     {

--- a/demo/embedded/index.json
+++ b/demo/embedded/index.json
@@ -41,7 +41,8 @@
       "name": "legend",
       "options": {
         "labelOpacitySlider": "Opacity",
-        "useGroupIndication" : true
+        "useGroupIndication" : true,
+        "hideWhenEmbedded": false
       }
     },
     {
@@ -75,6 +76,7 @@
     2396422,
     8973750
   ],
+  "constrainResolution": true,
   "proj4Defs": [
     {
         "code": "EPSG:3010",
@@ -139,16 +141,15 @@
   ],
   "layers": [
     {
-      "name": "sokvyx_park_park_lekplats",
-      "title": "Lekplatser",
+      "name": "sokvyxw_utegym",
+      "title": "Utegym",
       "group": "root",
       "queryable": true,
       "type": "WMS",
       "visible": true,
-      "searchable": true,
-      "source": "etuna",
-      "infoFormat": "text/html"
-    },
+      "source": "etuna"
+  },
+
     {
       "name": "osm",
       "title": "OpenStreetMap",
@@ -158,6 +159,7 @@
       "type": "OSM",
       "visible": true
     }
+
   ],
   "styles": {
     "karta_osm": [

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,26 +23,39 @@
 </head>
 <body>
 <select multiple></select>
-<iframe width="640" height="480" src="/demo/embedded/index.html"></iframe>
+<iframe width="640" height="480" src="../demo/embedded/index.html"></iframe>
 <script type="text/javascript">
 	const selectEl = document.getElementsByTagName("select")[0];
 	const iframeEl = document.getElementsByTagName("iframe")[0];
 
-	function sendMessage(command, payload) {
-		iframeEl.contentWindow.postMessage(`${command}:${payload}`, window.origin);
+	function sendMessage(message) {
+		iframeEl.contentWindow.postMessage(message, window.origin);
 	}
 
-	fetch('https://karta.eskilstuna.se/geoserver/etuna/wfs?SERVICE=WFS&VERSION=1.1.1&REQUEST=GetFeature&OUTPUTFORMAT=application/json&TYPENAMES=sokvyx_park_park_lekplats')
+	fetch('https://karta.eskilstuna.se/geoserver/etuna/wfs?SERVICE=WFS&VERSION=1.1.1&REQUEST=GetFeature&OUTPUTFORMAT=application/json&TYPENAMES=sokvyxw_utegym')
 			.then((res) => res.json())
 			.then((res) => {
 				res.features.forEach((f) => {
-					selectEl.add(new Option(f.properties.title, f.properties.sokid));
+					if (!f.properties.title.toLowerCase().includes(("test"))) {
+						selectEl.add(new Option(f.properties.title, f.properties.sv_global_id))
+					}
 				});
 			});
 	selectEl.addEventListener("input", (e) => {
 		const selected = [...e.target.options].filter((o) => o.selected);
-		sendMessage('setVisibleIDs', selected.map((o) => o.value).join(','));
-		sendMessage('zoomTo', selected[selected.length - 1].value);
+		const filterMessage = {
+			command: 'setVisibleIDs',
+    		targetLayer: 'sokvyxw_utegym',
+			ids: selected.map((o) => o.value)
+		}
+		const zoomToMessage = {
+			command: 'zoomTo',
+    		targetLayer: 'sokvyxw_utegym',
+			ids: selected.map((o) => o.value)
+		}
+			
+		sendMessage(filterMessage)
+		sendMessage(zoomToMessage)
 	});
 </script>
 </body>

--- a/tasks/webpack.dev.js
+++ b/tasks/webpack.dev.js
@@ -3,7 +3,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   output: {
-    path: `${__dirname}/../../origo/plugins`,
+    path: `${__dirname}/../out`,
     publicPath: '/build/js',
     filename: 'origoiframeetuna.js',
     libraryTarget: 'var',


### PR DESCRIPTION
…arget layer. Objects are easier to extend. The column/field to search could also be part of the object of course, it just isn't for our implementation (since the unique ids column will always be called the same thing)
Aims to fix #1 