### PR TITLE
fix: produce okay response from geoserver when empty array of ids

### DIFF
--- a/src/origoiframeetuna.js
+++ b/src/origoiframeetuna.js
@@ -32,6 +32,7 @@ const Origoiframeetuna = function Origoiframeetuna(options = {}) {
    * @returns {String[]}
    */
   function getFilterIds(ids) {
+    if (ids.length === 0) return "''";
     const newArray = ids.map(id => `'${id}'`);
     return newArray.join();
   }


### PR DESCRIPTION
Aims to fix #5 . If whatever sends the message sends it with an empty array as ids, probably indicating that whatever built the message object was associated with a search or a filtering action that produced 0 results, there will with this change be 0 features in the map. 